### PR TITLE
Fix: Bypass API deleteMany to prevent OOM on content deletion

### DIFF
--- a/lib/courseassetsModule.js
+++ b/lib/courseassetsModule.js
@@ -54,9 +54,11 @@ class CourseAssetsModule extends AbstractApiModule {
    */
   async handleContentEvent (action, arg1, arg2) {
     if (action === 'delete') {
+      const mongodb = await this.app.waitForModule('mongodb')
+      const collection = mongodb.getCollection(this.collectionName)
       return Promise.all((Array.isArray(arg1) ? arg1 : [arg1]).map(async c => {
         const key = c._type === 'course' ? 'courseId' : 'contentId'
-        await this.deleteMany({ [key]: c._id })
+        await collection.deleteMany({ [key]: c._id.toString() })
         this.log('debug', 'DELETE', c._courseId.toString(), c._id.toString())
       }))
     }
@@ -80,7 +82,8 @@ class CourseAssetsModule extends AbstractApiModule {
       }
     }
     // delete any existing course assets for content
-    await this.deleteMany({ courseId, contentId })
+    const mongodb = await this.app.waitForModule('mongodb')
+    await mongodb.getCollection(this.collectionName).deleteMany({ courseId, contentId })
 
     if (!ids.length) {
       return
@@ -90,7 +93,6 @@ class CourseAssetsModule extends AbstractApiModule {
     const validIds = ids.filter(id => foundIds.has(id))
 
     if (validIds.length) {
-      const mongodb = await this.app.waitForModule('mongodb')
       const docs = validIds.map(assetId => ({ courseId, contentId, assetId }))
       await mongodb.getCollection(this.collectionName).insertMany(docs)
     }

--- a/lib/courseassetsModule.js
+++ b/lib/courseassetsModule.js
@@ -20,7 +20,7 @@ class CourseAssetsModule extends AbstractApiModule {
   async init () {
     await super.init()
 
-    const [assets, content] = await this.app.waitForModule('assets', 'content')
+    const [assets, content, mongodb] = await this.app.waitForModule('assets', 'content', 'mongodb')
     /**
      * Cached module instance for easy access
      * @type {AssetsModule}
@@ -31,6 +31,10 @@ class CourseAssetsModule extends AbstractApiModule {
      * @type {ContentModule}
      */
     this.content = content
+    /** @ignore */
+    this.collection = mongodb.getCollection(this.collectionName)
+    /** @ignore */
+    this.pendingDeletes = { courseIds: new Set(), contentIds: new Set(), promise: null }
 
     this.assets.preDeleteHook.tap(this.handleDeletedAsset.bind(this));
 
@@ -55,20 +59,15 @@ class CourseAssetsModule extends AbstractApiModule {
   async handleContentEvent (action, arg1, arg2) {
     if (action === 'delete') {
       const items = Array.isArray(arg1) ? arg1 : [arg1]
-      const courseIds = []
-      const contentIds = []
       for (const c of items) {
-        if (c._type === 'course') courseIds.push(c._id.toString())
-        else contentIds.push(c._id.toString())
+        if (c._type === 'course') this.pendingDeletes.courseIds.add(c._id.toString())
+        else this.pendingDeletes.contentIds.add(c._id.toString())
       }
-      const mongodb = await this.app.waitForModule('mongodb')
-      const collection = mongodb.getCollection(this.collectionName)
-      const ops = []
-      if (courseIds.length) ops.push(collection.deleteMany({ courseId: { $in: courseIds } }))
-      if (contentIds.length) ops.push(collection.deleteMany({ contentId: { $in: contentIds } }))
-      await Promise.all(ops)
-      items.forEach(c => this.log('debug', 'DELETE', c._courseId.toString(), c._id.toString()))
-      return
+      if (!this.pendingDeletes.promise) {
+        this.pendingDeletes.promise = new Promise(resolve => setImmediate(resolve))
+          .then(() => this.flushDeletes())
+      }
+      return this.pendingDeletes.promise
     }
     const type = arg1._type
     const contentId = arg1._id.toString()
@@ -90,8 +89,7 @@ class CourseAssetsModule extends AbstractApiModule {
       }
     }
     // delete any existing course assets for content
-    const mongodb = await this.app.waitForModule('mongodb')
-    await mongodb.getCollection(this.collectionName).deleteMany({ courseId, contentId })
+    await this.collection.deleteMany({ courseId, contentId })
 
     if (!ids.length) {
       return
@@ -102,9 +100,20 @@ class CourseAssetsModule extends AbstractApiModule {
 
     if (validIds.length) {
       const docs = validIds.map(assetId => ({ courseId, contentId, assetId }))
-      await mongodb.getCollection(this.collectionName).insertMany(docs)
+      await this.collection.insertMany(docs)
     }
     this.log('debug', 'UPDATE', courseId, contentId)
+  }
+
+  async flushDeletes () {
+    const { courseIds, contentIds } = this.pendingDeletes
+    this.pendingDeletes = { courseIds: new Set(), contentIds: new Set(), promise: null }
+
+    const ops = []
+    if (courseIds.size) ops.push(this.collection.deleteMany({ courseId: { $in: [...courseIds] } }))
+    if (contentIds.size) ops.push(this.collection.deleteMany({ contentId: { $in: [...contentIds] } }))
+    await Promise.all(ops)
+    this.log('debug', 'DELETE', `${courseIds.size} courses, ${contentIds.size} content items`)
   }
 
   async handleDeletedAsset (asset) {

--- a/lib/courseassetsModule.js
+++ b/lib/courseassetsModule.js
@@ -54,13 +54,21 @@ class CourseAssetsModule extends AbstractApiModule {
    */
   async handleContentEvent (action, arg1, arg2) {
     if (action === 'delete') {
+      const items = Array.isArray(arg1) ? arg1 : [arg1]
+      const courseIds = []
+      const contentIds = []
+      for (const c of items) {
+        if (c._type === 'course') courseIds.push(c._id.toString())
+        else contentIds.push(c._id.toString())
+      }
       const mongodb = await this.app.waitForModule('mongodb')
       const collection = mongodb.getCollection(this.collectionName)
-      return Promise.all((Array.isArray(arg1) ? arg1 : [arg1]).map(async c => {
-        const key = c._type === 'course' ? 'courseId' : 'contentId'
-        await collection.deleteMany({ [key]: c._id.toString() })
-        this.log('debug', 'DELETE', c._courseId.toString(), c._id.toString())
-      }))
+      const ops = []
+      if (courseIds.length) ops.push(collection.deleteMany({ courseId: { $in: courseIds } }))
+      if (contentIds.length) ops.push(collection.deleteMany({ contentId: { $in: contentIds } }))
+      await Promise.all(ops)
+      items.forEach(c => this.log('debug', 'DELETE', c._courseId.toString(), c._id.toString()))
+      return
     }
     const type = arg1._type
     const contentId = arg1._id.toString()


### PR DESCRIPTION
### Fix

- Replace `this.deleteMany()` with direct MongoDB `collection.deleteMany()` to avoid loading all matching documents into memory before deletion
- `AbstractApiModule.deleteMany` fetches every matching doc (for hook invocation), which causes OOM on multilang courses with thousands of courseasset records
- No courseasset post-delete hook observers exist, so the fetch is pure overhead

### Testing

- [ ] Delete a block in a multilang course — should no longer OOM
- [ ] Delete a course — verify all courseasset records are cleaned up
- [ ] Verify courseasset query endpoint still returns correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)